### PR TITLE
Support for ndk r10c

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ cd build
 make
 ````
 
+Warning: by default, the build script will attempt to compile using the latest
+Android API. If you compile fb-adb using android-21 or later, your binary will
+be incompatible with older versions of Android.  To maintain compatibility
+while using the latest NDK version, you have to manually specify the target sdk
+version:
+````
+../configure --with-android-platform=19
+````
+
 RUNNING
 -------
 

--- a/child.c
+++ b/child.c
@@ -118,7 +118,19 @@ child_start(const struct child_start_info* csi)
             die_errno("grantpt/unlockpt");
 
 #ifdef HAVE_PTSNAME
-        char* pty_slave_name = xstrdup(ptsname(pty_master));
+        char* pty_slave_name = NULL;
+/*
+ * stdlib.h provided by OS X does not declare ptsname_r()
+ */
+#ifdef __APPLE__
+        pty_slave_name = xstrdup(ptsname(pty_master));
+#else
+        size_t buflen = 256;
+        char buffer[buflen];
+        ptsname_r(pty_master, buffer, buflen);
+        pty_slave_name = xstrdup(buffer);
+#endif
+
 #else
         int pty_slave_num;
         if (ioctl(pty_master, TIOCGPTN, &pty_slave_num) != 0)


### PR DESCRIPTION
Android ndk r10c introduces a new warning that breaks fb-adb when we use android-21.

To fix this, this patch migrates from ptsname() to ptsname_r() when building
the Android binaries. Unfortunately, OS X does not provide ptsname_r(), so an
exception is required for this specific case.

Also, when compiling using Android-21 or later, the resulting binaries are
incompatible with older (<5.0) versions of Android. A warning has been added to
the README file to assist users.

This commit fixes #8
