### PR TITLE
Sensible error bash

### DIFF
--- a/fb-adb.bashsrc.in
+++ b/fb-adb.bashsrc.in
@@ -7,12 +7,6 @@
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
 
-if [[  -n "$BASH_VERSINFO" && "$BASH_VERSINFO" -lt 4 ]]; then
-  echo Completion not supported prior to Bash 4.
-  echo If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.
-  # This is evaluated, so don't exit as that would exit the user's shell
-fi
-
 if [[ -z $_fb_adb_print_messages ]]; then
     _fb_adb_print_messages=no
 fi
@@ -1049,7 +1043,13 @@ _fb_adb_complete() {
     fi
 }
 
-complete -F _fb_adb_complete fb-adb
+if [[  -n "$BASH_VERSINFO" && "$BASH_VERSINFO" -lt 4 ]]; then
+  echo Completion not supported prior to Bash 4.
+  echo If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.
+  # This is evaluated, so don't exit as that would exit the user's shell
+else
+  complete -F _fb_adb_complete fb-adb
+fi
 
 ##############################
 # GENERATED CODE BEGINS HERE #

--- a/fb-adb.bashsrc.in
+++ b/fb-adb.bashsrc.in
@@ -7,6 +7,12 @@
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
 
+if [[ "$BASH_VERSINFO" -lt 4 ]]; then
+  echo Completion not supported prior to Bash 4.
+  echo If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.
+  # This is evaluated, so don't exit as that would exit the user's shell
+fi
+
 if [[ -z $_fb_adb_print_messages ]]; then
     _fb_adb_print_messages=no
 fi

--- a/fb-adb.bashsrc.in
+++ b/fb-adb.bashsrc.in
@@ -7,7 +7,7 @@
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
 
-if [[ "$BASH_VERSINFO" -lt 4 ]]; then
+if [[  -n "$BASH_VERSINFO" && "$BASH_VERSINFO" -lt 4 ]]; then
   echo Completion not supported prior to Bash 4.
   echo If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.
   # This is evaluated, so don't exit as that would exit the user's shell

--- a/fb-adb.bashsrc.in
+++ b/fb-adb.bashsrc.in
@@ -11,11 +11,6 @@ if [[ -z $_fb_adb_print_messages ]]; then
     _fb_adb_print_messages=no
 fi
 
-if ! type -p jq >/dev/null 2>&1; then
-    printf >&2 'WARNING: jq not found\n'
-    printf >&2 'fb-adb completion relies on the jq utility\n'
-fi
-
 : ${_fb_adb:=fb-adb}
 
 if ! type -p "$_fb_adb" >/dev/null 2>&1; then
@@ -1043,12 +1038,17 @@ _fb_adb_complete() {
     fi
 }
 
+# This is evaluated, so don't exit on error as that would exit the user's shell
 if [[  -n "$BASH_VERSINFO" && "$BASH_VERSINFO" -lt 4 ]]; then
-  echo Completion not supported prior to Bash 4.
-  echo If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.
-  # This is evaluated, so don't exit as that would exit the user's shell
+    printf >&2 'Completion not supported prior to Bash 4.\n'
+    printf >&2 'If you are on Mac, see http://apple.stackexchange.com/a/24635 for how to upgrade Bash.\n'
+elif ! type -p jq >/dev/null 2>&1; then
+    printf >&2 'ERROR: jq not found\n'
+    printf >&2 'fb-adb completion relies on the jq utility\n'
+    printf >&2 'if you are on Mac and use homebrew: brew install jq\n'
 else
-  complete -F _fb_adb_complete fb-adb
+    # All good, install completion function
+    complete -F _fb_adb_complete fb-adb
 fi
 
 ##############################


### PR DESCRIPTION
Bash on Mac is 3.2 by default. Completion is messed up. compopt is missing and "complete -o nospace" seems to require additional arguments. I failed to get it to work, but a decent error message seems better than nothing.

I've tested on bash 3.2 and bash 4.3.