### PR TITLE
FreeBSD support

### DIFF
--- a/Makefile.am.fb-adb
+++ b/Makefile.am.fb-adb
@@ -48,7 +48,7 @@ $(STUB_BINARIES:/stub=/.update-lib):
 nodist_fb_adb_SOURCES += stubs.c
 CLEANFILES += stubs.c
 stubs.c: $(srcdir)/mkstubsc.sh update-all-stubs
-	XXD="$(XXD)" $(srcdir)/mkstubsc.sh $(STUB_BINARIES) > $@.tmp
+	XXD="$(XXD)" $(BASH) $(srcdir)/mkstubsc.sh $(STUB_BINARIES) > $@.tmp
 	cmp 2>/dev/null $@ $@.tmp || mv -f $@.tmp $@
 
 EXTRA_DIST += mk-fingerprint.py arpy.py

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,7 @@ else
       fi
      echo "Configuring native NDK toolchain for $platform/$toolchain_cpu"
 
+     ${ANDROID_NDK_SHELL} \
      "$andk"/build/tools/make-standalone-toolchain.sh \
        --install-dir=toolchain --platform=$platform \
        --arch=$toolchain_cpu

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,11 @@ AC_CHECK_TOOLS(AR, [gcc-ar ar])
 AC_CHECK_TOOLS(STRIP, [strip])
 AM_PROG_AR
 
+AC_CHECK_PROGS(BASH, [bash zsh], [
+  AC_MSG_ERROR([bash or zsh required for building])
+])
+export BASH # for AC_CONFIG_SUBDIRS
+
 AC_CHECK_PROGS(PYTHON3, [python3], [
   AC_MSG_ERROR([python3 required for building])
 ])

--- a/fb-adb.bashsrc.in
+++ b/fb-adb.bashsrc.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014, Facebook, Inc.
 # All rights reserved.
 #

--- a/fdrecorder.c
+++ b/fdrecorder.c
@@ -18,7 +18,7 @@
 #include "net.h"
 
 #ifndef FDRECORDER_USE_PIPE
-# if defined(__linux__)
+# ifdef HAVE_PIPE2
 #  define FDRECORDER_USE_PIPE 1
 # else
 #  define FDRECORDER_USE_PIPE 0
@@ -29,7 +29,7 @@ __attribute__((unused))
 static void
 xshutdown_if_not_broken(int socket, int how)
 {
-#ifndef __APPLE__
+#if FDRECORDER_USE_PIPE
     xshutdown(socket, how);
 #endif
 }

--- a/mkstubsc.sh
+++ b/mkstubsc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014, Facebook, Inc.
 # All rights reserved.
 #

--- a/net.h
+++ b/net.h
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <sys/socket.h>
 

--- a/stub-arm-pic/configure
+++ b/stub-arm-pic/configure
@@ -6,4 +6,4 @@
 # the LICENSE file in the root directory of this source tree. An
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
-exec "$(dirname "$0")"/../stub-config.sh arm-linux-androideabi BUILD_PIC=1 "$@"
+exec $BASH "$(dirname "$0")"/../stub-config.sh arm-linux-androideabi BUILD_PIC=1 "$@"

--- a/stub-arm/configure
+++ b/stub-arm/configure
@@ -6,4 +6,4 @@
 # the LICENSE file in the root directory of this source tree. An
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
-exec "$(dirname "$0")"/../stub-config.sh arm-linux-androideabi "$@"
+exec $BASH "$(dirname "$0")"/../stub-config.sh arm-linux-androideabi "$@"

--- a/stub-config.sh
+++ b/stub-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2014, Facebook, Inc.
 # All rights reserved.
 #

--- a/stub-local/configure
+++ b/stub-local/configure
@@ -6,4 +6,4 @@
 # the LICENSE file in the root directory of this source tree. An
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
-exec "$(dirname "$0")"/../stub-config.sh local "$@"
+exec $BASH "$(dirname "$0")"/../stub-config.sh local "$@"

--- a/stub-x86-pic/configure
+++ b/stub-x86-pic/configure
@@ -6,4 +6,4 @@
 # the LICENSE file in the root directory of this source tree. An
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
-exec "$(dirname "$0")"/../stub-config.sh i686-linux-android BUILD_PIC=1 "$@"
+exec $BASH "$(dirname "$0")"/../stub-config.sh i686-linux-android BUILD_PIC=1 "$@"

--- a/stub-x86/configure
+++ b/stub-x86/configure
@@ -6,4 +6,4 @@
 # the LICENSE file in the root directory of this source tree. An
 # additional grant of patent rights can be found in the PATENTS file
 # in the same directory.
-exec "$(dirname "$0")"/../stub-config.sh i686-linux-android "$@"
+exec $BASH "$(dirname "$0")"/../stub-config.sh i686-linux-android "$@"

--- a/stubdaemon.c
+++ b/stubdaemon.c
@@ -31,7 +31,9 @@ fb_adb_service_connect(const char* package, int timeout_ms)
 {
     SCOPED_RESLIST(rl);
 
+#ifdef SO_PEERCRED
     uid_t expected_uid = xstat(xaprintf("/data/data/%s", package)).st_uid;
+#endif
 
     const char* service_sockname =
         xaprintf("fb-adb-service-%s",
@@ -87,6 +89,7 @@ fb_adb_service_connect(const char* package, int timeout_ms)
                    "timeout waiting for service callback");
     WITH_CURRENT_RESLIST(rl->parent);
     int connection = xaccept(service_listen_fd);
+#ifdef SO_PEERCRED
     uid_t connection_uid = get_peer_credentials(connection).uid;
     if (connection_uid != expected_uid)
         die(ECOMM, "expected uid %d for package [%s] "
@@ -94,6 +97,7 @@ fb_adb_service_connect(const char* package, int timeout_ms)
             (int) expected_uid,
             package,
             (int) connection_uid);
+#endif
     return connection;
 }
 

--- a/stubdaemon.c
+++ b/stubdaemon.c
@@ -10,6 +10,7 @@
  */
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <string.h>
 #include "stubdaemon.h"
 #include "util.h"
 #include "fs.h"

--- a/xfer.c
+++ b/xfer.c
@@ -14,6 +14,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include "util.h"
 #include "autocmd.h"
 #include "xfer.h"


### PR DESCRIPTION
**EDIT**: less relevant stuff moved into [another](https://reviews.freebsd.org/D3930) review request.

A few fixes from FreeBSD port. Most **fb-adb** commands seem to work fine while **adb** commands don't (likely #25).

One patch isn't worth upstreaming as our old toolchain is being phased out:
```compile
libfb-adb.a(cmd_shex.o): In function `reconnect_over_tcp_socket':
cmd_shex.c:(.text+0xbab): undefined reference to `__builtin_unreachable'
```
```diff
--- util.c.orig	2015-10-09 22:02:18 UTC
+++ util.c
@@ -1563,3 +1563,9 @@ xregerror(int errcode, const regex_t* pr
     reslist_xfer(rl->parent, rl);
     return (char*) gb.buf;
 }
+
+#ifndef __linux__
+// XXX For GCC 4.4 or older
+__weak_reference(my_unreachable, __builtin_unreachable);
+void my_unreachable() { abort(); }
+#endif
```
