### PR TITLE
Use ppoll(2) on FreeBSD 10.2 but not GNU/kFreeBSD

### DIFF
--- a/fs.h
+++ b/fs.h
@@ -100,9 +100,11 @@ int dup3(int oldfd, int newfd, int flags);
 
 #if defined(__linux__)
 # define XPPOLL XPPOLL_LINUX_SYSCALL
+#elif defined(HAVE_PPOLL) && !defined(__GLIBC__)
+# define XPPOLL XPPOLL_SYSTEM
 #elif defined(HAVE_KQUEUE)
 # define XPPOLL XPPOLL_KQUEUE
-#elif defined(HAVE_PPOLL)
+#elif defined(HAVE_PPOLL) && defined(__GLIBC__)
 # define XPPOLL XPPOLL_SYSTEM
 # define XPPOLL_BROKEN 1
 #else


### PR DESCRIPTION
From #38 by @dcolascione:
> I'd also love to see properly-supported ppoll and pselect
> implementations. It's much less awkward to implement those in the
> kernel than to emulate them using kqueue.

I guess, you're referring to [XPPOLL_BROKEN comment](https://github.com/facebook/fb-adb/blob/9c4e01f/fs.h#L113). GNU/Linux and GNU/kFreeBSD use glibc thus ppoll(3) maybe a wrapper around poll(2) if ppoll(2) isn't available. With ppoll(2) available it doesn't seem to do anything fancy that'd make it non-atomic.

http://code.metager.de/source/xref/gnu/glibc/sysdeps/unix/sysv/linux/ppoll.c#35

How to detect which ppoll() glibc uses or what to do with non-glibc Linux is left for another time. Otherwise, Linux, glibc or OS X bugs don't apply to BSDs or Solaris which use different kernel, libc, libpthread implementations.
