### PR TITLE
Fix error "[child] expected 0x65 e, found 0x1b ." on some firmwares.

### DIFF
--- a/chat.c
+++ b/chat.c
@@ -56,12 +56,15 @@ chat_expect(struct chat* cc, char expected)
     }
 }
 
-void
+bool
 chat_expect_maybe(struct chat* cc, char expected)
 {
     char c = chat_getc(cc);
-    if (c != expected)
+    if (c != expected) {
         ungetc(c, cc->from);
+        return false;
+    }
+    return true;
 }
 
 void
@@ -139,6 +142,19 @@ chat_talk_at(struct chat* cc, const char* what)
 
     if (fflush(cc->to) == EOF)
         chat_die();
+
+    /* When busybox is built with FEATURE_EDITING_ASK_TERMINAL, it may
+     * send us ESC"[6n" immediately after the prompt if its input
+     * buffer is empty.  There is no need to respond; busybox just
+     * sleeps for 20ms and then continues. */
+    if (*what && !chat_expect_maybe(cc, *what++)) {
+        what--;
+        if (chat_expect_maybe(cc, '\033')) {
+            chat_expect(cc, '[');
+            chat_expect(cc, '6');
+            chat_expect(cc, 'n');
+        }
+    }
 
     /* We expect the child to echo us, so read back the echoed
      * characters.  */

--- a/chat.h
+++ b/chat.h
@@ -21,6 +21,7 @@ struct chat {
 struct chat* chat_new(int to, int from);
 char chat_getc(struct chat* cc);
 void chat_expect(struct chat* cc, char expected);
-void chat_swallow_prompt(struct chat* cc);
-void chat_talk_at(struct chat* cc, const char* what);
+void chat_talk_at(struct chat* cc, const char* what, int flags);
 char* chat_read_line(struct chat* cc);
+
+#define CHAT_SWALLOW_PROMPT 0x1

--- a/cmd_shex.c
+++ b/cmd_shex.c
@@ -244,7 +244,6 @@ try_adb_stub(const struct child_start_info* csi,
     struct chat* cc = chat_new(
         child->fd[STDIN_FILENO]->fd,
         child->fd[STDOUT_FILENO]->fd);
-    chat_swallow_prompt(cc);
 
     *err = NULL;
 
@@ -278,11 +277,11 @@ try_adb_stub(const struct child_start_info* csi,
         // The extra round trip sucks, but if we don't do this, mksh's
         // helpful line editing will screw up our echo detection.
         unsigned long total_promptw = promptw + strlen(cmd);
-        chat_talk_at(cc, xaprintf("COLUMNS=%lu", total_promptw));
-        chat_swallow_prompt(cc);
+        chat_talk_at(cc, xaprintf("COLUMNS=%lu", total_promptw),
+                     CHAT_SWALLOW_PROMPT);
     }
 
-    chat_talk_at(cc, cmd);
+    chat_talk_at(cc, cmd, CHAT_SWALLOW_PROMPT);
     char* resp = chat_read_line(cc);
     dbg("stub resp: [%s]", resp);
 


### PR DESCRIPTION
This occurs when busybox is built with FEATURE_EDITING_ASK_TERMINAL,
such as on TWRP recovery firmwares.

(Note that /system must be mounted before connecting to a recovery
firmware with fb-adb.)