### PR TITLE
Update fb-adb to work with Nougat adb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,14 +92,12 @@ if test "$platform" = "system"; then
 else
   if test -n "$BUILD_STUB" && test -z "$STUB_LOCAL"; then
      rm -rf toolchain
-     mkdir -p toolchain
      if test $host_cpu = i686; then
         toolchain_cpu=x86
       else
         toolchain_cpu=arm
       fi
      echo "Configuring native NDK toolchain for $platform/$toolchain_cpu"
-
      ${ANDROID_NDK_SHELL} \
      "$andk"/build/tools/make-standalone-toolchain.sh \
        --install-dir=toolchain --platform=$platform \

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,10 @@ if ! test -d "$sdk/build-tools"; then
    AC_MSG_ERROR([Android SDK not in "$sdk"])
 fi
 
+if ! test -f "$sdk/platforms/android-19/android.jar"; then
+   AC_MSG_ERROR([Android SDK does not include API 19 SDK: please download API 19 SDK])
+fi
+
 latest_tools_version=$(ls -r1 "$sdk/build-tools" | head -n1)
 ANDROID_SDK_TOOLS_DIRECTORY=$sdk/build-tools/$latest_tools_version
 if ! test -f "$ANDROID_SDK_TOOLS_DIRECTORY/dx"; then

--- a/util.c
+++ b/util.c
@@ -1681,6 +1681,35 @@ grow_buffer_dwim(struct growable_buffer* gb)
     resize_buffer(gb, bufsz);
 }
 
+void
+growable_string_append_c(struct growable_string* gs, char c)
+{
+    assert(gs->strlen <= gs->gb.bufsz);
+    if (gs->strlen == gs->gb.bufsz)
+        grow_buffer_dwim(&gs->gb);
+    assert(gs->strlen < gs->gb.bufsz);
+    gs->gb.buf[gs->strlen++] = c;
+}
+
+void
+growable_string_trim_trailing_whitespace(struct growable_string* gs)
+{
+    while (gs->strlen > 0 && strchr(" \t\r\n\v", gs->gb.buf[gs->strlen - 1]))
+        gs->strlen--;
+}
+
+const char*
+growable_string_c_str(struct growable_string* gs)
+{
+    assert(gs->strlen <= gs->gb.bufsz);
+    if (gs->strlen == gs->gb.bufsz) {
+        grow_buffer_dwim(&gs->gb);
+    }
+    assert(gs->strlen < gs->gb.bufsz);
+    gs->gb.buf[gs->strlen] = '\0';
+    return (const char*) &gs->gb.buf[0];
+}
+
 static void
 cleanup_regfree(void* data)
 {

--- a/util.h
+++ b/util.h
@@ -372,6 +372,18 @@ void resize_buffer(struct growable_buffer* gb, size_t new_size);
 void grow_buffer(struct growable_buffer* gb, size_t min);
 void grow_buffer_dwim(struct growable_buffer* gb);
 
+// Like growable_buffer, but deals in characters and automatically
+// NUL-terminates
+
+struct growable_string {
+    struct growable_buffer gb;
+    size_t strlen;
+};
+
+void growable_string_append_c(struct growable_string* gs, char c);
+const char* growable_string_c_str(struct growable_string* gs);
+void growable_string_trim_trailing_whitespace(struct growable_string* gs);
+
 regex_t* xregcomp(const char* regex, int cflags);
 char* xregerror(int errcode, const regex_t* preg);
 


### PR DESCRIPTION
Previously, we'd hang when trying to connect to an N device using an N adb. Don't do that anymore. See the last commit in the series for more detailed information.

This diff imposes a performance cost of one adb invocation in the non-daemon case when using an old adb or when using a new adb with an old device, but let's optimize for the future. In principle, we could use caching to address this performance hit, but since I expect most users to use the fast daemon invocation anyway (it happens automatically), this caching probably isn't worth the complexity.