### PR TITLE
Look up __system_property_find_nth dynamically

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ CMD_SOURCES = \
 	cmd_getprop.c \
 	cmd_help.c \
 	cmd_logwrite.c \
+	cmd_ping.c \
 	cmd_ps_json.c \
 	cmd_rdex.c \
 	cmd_xdex.c \

--- a/Makefile.am.fb-adb
+++ b/Makefile.am.fb-adb
@@ -17,6 +17,7 @@ CMD_SOURCES += \
 	cmd_fput.c \
 	cmd_logcat_json.c \
 	cmd_shex.c \
+	cmd_ping.c \
 	cmd_jdwp.c \
 	peer.c \
 	peer.h \

--- a/Makefile.am.stub
+++ b/Makefile.am.stub
@@ -24,6 +24,7 @@ libfb_adb_a_SOURCES += \
 CMD_SOURCES += \
 	cmd_stub.c \
 	cmd_stub_package_hack.c \
+	cmd_echo.c \
 	$(EMPTY)
 
 check_PROGRAMS = fb-adb

--- a/adbenc.c
+++ b/adbenc.c
@@ -25,13 +25,13 @@ static const char adb_escape1 = '!';
 static const char adb_escape2 = '@';
 
 void
-adb_encode(unsigned* inout_state,
+adb_encode(uint8_t* inout_state,
            char** inout_enc,
            char* encend,
            const char** inout_in,
            const char* inend)
 {
-    unsigned state = *inout_state;
+    uint8_t state = *inout_state;
     char* enc = *inout_enc;
     const char* in = *inout_in;
 
@@ -63,13 +63,13 @@ adb_encode(unsigned* inout_state,
 }
 
 void
-adb_decode(unsigned* inout_state,
+adb_decode(uint8_t* inout_state,
            char** inout_dec,
            char* decend,
            const char** inout_in,
            const char* inend)
 {
-    unsigned state = *inout_state;
+    uint8_t state = *inout_state;
     char* dec = *inout_dec;
     const char* in = *inout_in;
 
@@ -99,7 +99,7 @@ size_t
 read_all_adb_encoded(int fd, void* buf, size_t sz)
 {
     char encbuf[4096];
-    unsigned state = 0;
+    uint8_t state = 0;
     char* dec = buf;
     char* decend = dec + sz;
     ssize_t ret;
@@ -131,7 +131,7 @@ void
 write_all_adb_encoded(int fd, const void* buf, size_t sz)
 {
     char encbuf[4096];
-    unsigned state = 0;
+    uint8_t state = 0;
     const char* in = buf;
     const char* inend = in + sz;
     size_t nr_written = 0;

--- a/adbenc.h
+++ b/adbenc.h
@@ -9,14 +9,15 @@
  *
  */
 #pragma once
+#include <stdint.h>
 
-void adb_encode(unsigned* inout_state,
+void adb_encode(uint8_t* inout_state,
                 char** inout_enc,
                 char* encend,
                 const char** inout_in,
                 const char* inend);
 
-void adb_decode(unsigned* inout_state,
+void adb_decode(uint8_t* inout_state,
                 char** inout_dec,
                 char* decend,
                 const char** inout_in,

--- a/channel.c
+++ b/channel.c
@@ -220,6 +220,7 @@ channel_write(struct channel* c, const struct iovec* iov, unsigned nio)
         return; // If the stream is closed, just discard
 
     bool try_direct = !c->always_buffer && ringbuf_size(c->rb) == 0;
+    try_direct = false; // XXX
     size_t directwrsz = 0;
     size_t totalsz;
 

--- a/channel.c
+++ b/channel.c
@@ -64,7 +64,10 @@ channel_wanted_writesz(struct channel* c)
     if (c->fdh == NULL)
         return 0;
 
-    return XMIN(ringbuf_size(c->rb), UINT32_MAX - c->bytes_written);
+    // If c->adb_hack_state is non-zero, we need to write the second
+    // half of an adb-escaped character pair.
+    return XMIN(ringbuf_size(c->rb), UINT32_MAX - c->bytes_written)
+        + !!(c->adb_hack_state);
 }
 
 static size_t
@@ -105,7 +108,6 @@ channel_read_adb_hack(struct channel* c, size_t sz)
 
         struct iovec iov[2];
         ringbuf_writable_iov(c->rb, iov, chunksz);
-        unsigned state = c->leftover_escape;
         const char* in = buf;
         const char* inend = in + chunksz;
         size_t np = 0;
@@ -113,7 +115,7 @@ channel_read_adb_hack(struct channel* c, size_t sz)
             char* decstart = iov[i].iov_base;
             char* dec = decstart;
             char* decend = dec + iov[i].iov_len;
-            adb_decode(&state, &dec, decend, &in, inend);
+            adb_decode(&c->adb_hack_state, &dec, decend, &in, inend);
             np += (dec - decstart);
         }
 
@@ -124,77 +126,67 @@ channel_read_adb_hack(struct channel* c, size_t sz)
     return nr_added;
 }
 
-static ssize_t
-write_skip(int fd, const void* buf, size_t sz, size_t skip)
-{
-    assert(skip <= sz);
-    buf = (const char*) buf + skip;
-    sz -= skip;
-    WITH_IO_SIGNALS_ALLOWED();
-    ssize_t nr_written = write(fd, buf, sz);
-    if (nr_written >= 0)
-        nr_written += skip;
-
-    return nr_written;
-}
-
 static size_t
 channel_write_adb_hack(struct channel* c, size_t sz)
 {
-    size_t nr_removed = 0;
+    assert(sz > 0);
+    if (c->adb_hack_state)
+        sz -= 1;
 
-    while (nr_removed < sz) {
+    size_t nr_removed = 0;
+    do {
         struct iovec iov[2];
         char encbuf[4096];
         char* enc;
         char* encend;
-        unsigned state;
 
         ringbuf_readable_iov(c->rb, iov, sz - nr_removed);
+        uint8_t pass1_state = c->adb_hack_state;
+
         enc = encbuf;
         encend = enc + sizeof (encbuf);
-        state = c->leftover_escape;
         for (int i = 0; i < ARRAYSIZE(iov); ++i) {
             const char* in = iov[i].iov_base;
             const char* inend = in + iov[i].iov_len;
-            adb_encode(&state, &enc, encend, &in, inend);
+            adb_encode(&pass1_state, &enc, encend, &in, inend);
         }
 
-        // If we left a byte in the ringbuffer, don't actually write
-        // its first half now (since we wrote it before), but pretend
-        // we did.
-        size_t skip = (c->leftover_escape != 0);
-        ssize_t nr_written =
-            write_skip(c->fdh->fd, encbuf, enc - encbuf, skip);
+        size_t nr_encoded = enc - encbuf;
+        ssize_t nr_written;
+        {
+            WITH_IO_SIGNALS_ALLOWED();
+            nr_written = write(c->fdh->fd, encbuf, nr_encoded);
+        }
 
         if (nr_written < 0 && nr_removed == 0)
             die_errno("write");
-        if (nr_written < 0)
+        if (nr_written < 0) {
+            // write didn't actually write anything, so don't write
+            // pass1_state back into c.
             break;
+        }
 
-        size_t nr_encoded = 0;
+        // We wrote nr_written _encoded_ bytes, which may be less than
+        // the number of bytes we wanted to write post-encoding;
+        // the latter number is nr_encoded.  Re-run the encoder
+        // pretending we have only nr_written bytes available for
+        // encoding --- this way, next time, we'll resume exactly
+        // where we left off.
+
+        assert(nr_written <= sizeof (encbuf));
         enc = encbuf;
         encend = enc + nr_written;
-        state = c->leftover_escape;
+        size_t plaintext_consumed = 0;
         for (int i = 0; i < ARRAYSIZE(iov); ++i) {
-            const char* in = iov[i].iov_base;
+            const char* in_start = iov[i].iov_base;
+            const char* in = in_start;
             const char* inend = in + iov[i].iov_len;
-            adb_encode(&state, &enc, encend, &in, inend);
-            nr_encoded += (in - (char*) iov[i].iov_base);
+            adb_encode(&c->adb_hack_state, &enc, encend, &in, inend);
+            plaintext_consumed += (in - in_start);
         }
-
-        // If we wrote a partial encoded byte, leave the plain byte in
-        // the ringbuf so that we know this channel still needs to
-        // write.
-        if (state != 0) {
-            assert(nr_encoded > 0);
-            nr_encoded -= 1;
-        }
-
-        ringbuf_note_removed(c->rb, nr_encoded);
-        nr_removed += nr_encoded;
-        c->leftover_escape = state;
-    }
+        ringbuf_note_removed(c->rb, plaintext_consumed);
+        nr_removed += plaintext_consumed;
+    } while (nr_removed < sz);
 
     return nr_removed;
 }
@@ -220,7 +212,6 @@ channel_write(struct channel* c, const struct iovec* iov, unsigned nio)
         return; // If the stream is closed, just discard
 
     bool try_direct = !c->always_buffer && ringbuf_size(c->rb) == 0;
-    try_direct = false; // XXX
     size_t directwrsz = 0;
     size_t totalsz;
 

--- a/channel.h
+++ b/channel.h
@@ -29,13 +29,13 @@ struct channel {
     struct ttysave* saved_term_state;
     uint32_t bytes_written;
     uint32_t window;
+    uint8_t adb_hack_state;
     unsigned sent_eof : 1;
     unsigned pending_close : 1;
     unsigned always_buffer : 1;
     unsigned track_bytes_written : 1;
     unsigned track_window : 1;
     unsigned adb_encoding_hack : 1;
-    unsigned leftover_escape : 2;
     unsigned compress : 1;
 #ifdef FBADB_CHANNEL_NONBLOCK_HACK
     unsigned nonblock_hack : 1;

--- a/cmd_echo.c
+++ b/cmd_echo.c
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in
+ *  the LICENSE file in the root directory of this source tree. An
+ *  additional grant of patent rights can be found in the PATENTS file
+ *  in the same directory.
+ *
+ */
+#include "util.h"
+#include "autocmd.h"
+#include "fs.h"
+
+#if !FBADB_MAIN
+
+int
+_echo_main(const struct cmd__echo_info* info)
+{
+    char buf[128];
+    ssize_t nr_read;
+    while ((nr_read = xread(STDIN_FILENO, buf, sizeof (buf))) > 0) {
+        write_all(STDOUT_FILENO, buf, nr_read);
+    }
+    return 0;
+}
+
+#endif

--- a/cmd_ping.c
+++ b/cmd_ping.c
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in
+ *  the LICENSE file in the root directory of this source tree. An
+ *  additional grant of patent rights can be found in the PATENTS file
+ *  in the same directory.
+ *
+ */
+#include <sys/time.h>
+#include "util.h"
+#include "autocmd.h"
+#include "peer.h"
+#include "fs.h"
+
+static
+void
+ping(struct child* peer)
+{
+    char csend = '.';
+    write_all(peer->fd[STDIN_FILENO]->fd, &csend, sizeof (csend));
+    char crecv;
+    if (!read_all(peer->fd[STDOUT_FILENO]->fd, &crecv, sizeof (crecv)))
+        die(EINVAL, "remote did not echo ping");
+    if (csend != crecv)
+        die(EINVAL, "child replied with wrong pong byte");
+}
+
+int
+ping_main(const struct cmd_ping_info* info)
+{
+    struct start_peer_info spi = {
+        .adb = info->adb,
+        .transport = info->transport,
+        .specified_io = true,
+        .io[STDIN_FILENO] = CHILD_IO_PIPE,
+        .io[STDOUT_FILENO] = CHILD_IO_PIPE,
+    };
+    struct child* peer = start_peer(
+        &spi, strlist_from_argv(ARGV("_echo")));
+    ping(peer);
+    double time_ping = seconds_since_epoch();
+    ping(peer);
+    double time_pong = seconds_since_epoch();
+    xprintf(xstdout, "%gms", (time_pong - time_ping) * 1000.0);
+    return 0;
+}
+

--- a/cmd_shex.c
+++ b/cmd_shex.c
@@ -2219,8 +2219,8 @@ shex_main_common(const struct shex_common_info* info)
     block_signal(SIGWINCH);
     signal(SIGWINCH, handle_sigwinch);
 
-    size_t command_ringbufsz = max_cmdsz * 4;
-    size_t stdio_ringbufsz = max_cmdsz * 2;
+    size_t command_ringbufsz = 1024 * 1024;
+    size_t stdio_ringbufsz = 1024 * 1024;
     struct msg_shex_hello* hello_msg =
         make_hello_msg(max_cmdsz,
                        stdio_ringbufsz,

--- a/cmd_stub.c
+++ b/cmd_stub.c
@@ -765,7 +765,10 @@ stub_main_1(const struct cmd_stub_info* info)
                                 CHANNEL_FROM_FD);
 
     ch[FROM_PEER]->window = UINT32_MAX;
-    ch[FROM_PEER]->adb_encoding_hack = !!(rdr == read_all_adb_encoded);
+    ch[FROM_PEER]->adb_encoding_hack = shex_hello->adb_encoding_hack;
+
+    dbg("using adb encoding hack: %s",
+        shex_hello->adb_encoding_hack ? "yes" : "no");
 
     ch[TO_PEER] = channel_new(fdh_dup(STDOUT_FILENO),
                               shex_hello->stub_send_bufsz,

--- a/commands.xml
+++ b/commands.xml
@@ -608,6 +608,14 @@ code, and bash completion file.
     <optgroup-reference name="xfer" />
   </command>
   <?endif?>
+  <command names="ping" env="main">
+    Measure round trip time to device.
+    <optgroup-reference name="adb"/>
+    <optgroup-reference name="transport" />
+  </command>
+  <command names="_echo" internal="yes" env="stub">
+    Internal command that echoes the input.
+  </command>
   <?ifdef FBADB_MAIN?>
   <command names="shell,shellx,sh">
     Run a command on device.  If <i>command</i> is not supplied, run

--- a/core.c
+++ b/core.c
@@ -371,6 +371,8 @@ xmit_data_lz4(struct channel* c,
         consumed_size + sizeof (struct msg_channel_data);
 
     if (out_size + sizeof (m) >= equiv_uncompressed) {
+        dbg("sending uncompressed: compression would have wasted %u bytes",
+            (unsigned)((out_size + sizeof (m)) - equiv_uncompressed));
         return xmit_data_uncompressed(
             c, chno, dst, consumed_size, maxoutmsg);
     }

--- a/dbg.c
+++ b/dbg.c
@@ -300,7 +300,7 @@ dbgch(const char* label, struct channel** ch, unsigned nrch)
 
         assert(p.fd == -1 || p.fd == c->fdh->fd);
 
-        dbg("  %-18s size:%-4zu room:%-4zu window:%-4d %s%-2s %p %s",
+        dbg("  %-18s size:%-4zu room:%-4zu window:%-4d %s%-2s %p %s%s",
             xaprintf("ch[%d=%s]", chno, chname(chno)),
             ringbuf_size(c->rb),
             ringbuf_room(c->rb),
@@ -310,7 +310,8 @@ dbgch(const char* label, struct channel** ch, unsigned nrch)
              ? xaprintf("%d", c->fdh->fd)
              : (c->sent_eof ? "!!" : "!?")),
             c,
-            pev);
+            pev,
+            c->adb_hack_state ? " *" : "");
     }
 }
 

--- a/fs.c
+++ b/fs.c
@@ -397,10 +397,23 @@ hack_reopen_tty(int fd)
 }
 
 size_t
+xread(int fd, void* buf, size_t sz)
+{
+    ssize_t ret;
+    {
+        WITH_IO_SIGNALS_ALLOWED();
+        ret = read(fd, buf, sz);
+    }
+    if (ret < 0)
+        die_errno("read(%d)", fd);
+    return ret;
+}
+
+size_t
 read_all(int fd, void* buf, size_t sz)
 {
     size_t nr_read = 0;
-    int ret;
+    ssize_t ret;
     char* pos = buf;
 
     while (nr_read < sz) {

--- a/fs.h
+++ b/fs.h
@@ -83,6 +83,10 @@ enum blocking_mode fd_set_blocking_mode(int fd, enum blocking_mode mode);
 
 void hack_reopen_tty(int fd);
 
+// Read up to SZ bytes from FD into BUF.  May return on short read
+// even without EOF.  Return zero to indicate EOF.
+size_t xread(int fd, void* buf, size_t sz);
+
 // Read SZ bytes from FD into BUF, retrying on EINTR.
 // May return short read on EOF.
 size_t read_all(int fd, void* buf, size_t sz);

--- a/proto.h
+++ b/proto.h
@@ -131,7 +131,8 @@ struct msg_shex_hello {
     struct window_size ws;
     uint8_t have_ws;
     uint8_t posix_vdisable_value;
-    uint8_t ctty_p;
+    uint8_t ctty_p : 1;
+    uint8_t adb_encoding_hack : 1;
     struct stream_information si[3];
     struct term_control tctl[0]; // Must be last
 };

--- a/ringbuf.c
+++ b/ringbuf.c
@@ -110,6 +110,10 @@ ringbuf_note_removed(struct ringbuf* rb, size_t nr)
 {
     assert(nr <= ringbuf_size(rb));
     rb->nr_removed += nr;
+    if (ringbuf_size(rb) == 0) {
+        rb->nr_added = 0;
+        rb->nr_removed = 0;
+    }
     return nr;
 }
 


### PR DESCRIPTION
Some very recent Android systems don't have a
__system_property_find_nth, making the fb-adb stub fail to load.
We need this symbol only on very old Android versions, ones lacking
__system_property_foreach, so just load both symbols dynamically.