### PR TITLE
Fix building with NDK r15 beta2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,22 @@ if test -n "$BUILD_STUB"; then
 fi
 
 
+AC_MSG_CHECKING([if NDK defaults to unified headers])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[
+        #include <android/api-level.h>
+    ]], [[
+        #if defined(__ANDROID_API_FUTURE__) && __ANDROID_API_FUTURE__ == __ANDROID_API__
+            #error Unified headers detected
+        #endif
+    ]])],
+    [ac_ndk_use_unified_headers=no],
+    [ac_ndk_use_unified_headers=yes])
+AC_MSG_RESULT([$ac_ndk_use_unified_headers])
+if test "$ac_ndk_use_unified_headers" = "yes"; then
+    CPPFLAGS="$CPPFLAGS -D__ANDROID_API__=${platform/android-/}"
+fi
+
 AC_CHECK_FUNCS([ppoll signalfd4 dup3 mkostemp kqueue pipe2 ptsname])
 AC_CHECK_FUNCS([accept4 fopencookie funopen clock_gettime execvpe])
 AC_CHECK_FUNCS([fallocate futimes posix_fallocate ftruncate64])


### PR DESCRIPTION
NDK r15 will default to unified headers, which requires an extra
-D__ANDROID_API__=XX in $CPPFLAGS

From "Known issues" of https://android.googlesource.com/platform/ndk.git/+/master/docs/UnifiedHeaders.md:

> Standalone toolchains using GCC are not supported out of the box. To use GCC, pass -D__ANDROID_API__=$API when compiling. Note: this is not something we will be fixing.

The ```__ANDROID_API_FUTURE__``` trick is inspired by the new api-level.h in unified headers:
```C
#ifndef __ANDROID_API_FUTURE__
#define __ANDROID_API_FUTURE__ 10000
#endif

#ifndef __ANDROID_API__
#define __ANDROID_API__ __ANDROID_API_FUTURE__
#endif
```