### PR TITLE
Fix logcat-json command to honor adb parameters

### DIFF
--- a/cmd_logcat_json.c
+++ b/cmd_logcat_json.c
@@ -197,7 +197,7 @@ logcat_json_main(const struct cmd_logcat_json_info* info)
     struct strlist* args = strlist_new();
     strlist_append(args, orig_argv0);
     strlist_append(args, "shell");
-    strlist_xfer(args, make_args_cmd_shell(CMD_ARG_FORWARDED, &shcmdi));
+    strlist_xfer(args, make_args_cmd_shell(CMD_ARG_ALL, &shcmdi));
 
     struct child_start_info csi = {
         .io[STDIN_FILENO] = CHILD_IO_DEV_NULL,


### PR DESCRIPTION
Since adb parameters are not forwarded, options
like -d/-e are not working and logcat-json
refures to work when more than one device
is connected at the same time