### PR TITLE
Defer unix socket cleanup until after the shell exits

### DIFF
--- a/cmd_shex.c
+++ b/cmd_shex.c
@@ -971,7 +971,6 @@ connect_to_device_socket(
     const char* const* adb_args,
     const char* device_socket)
 {
-    SCOPED_RESLIST(rl);
     char* host_socket =
         xaprintf("%s/fb-adb-conn-%s.sock",
                  system_tempdir(),
@@ -990,7 +989,6 @@ connect_to_device_socket(
     int scon = xsocket(AF_UNIX, SOCK_STREAM, 0);
     xconnect(scon, make_addr_unix_filesystem(host_socket));
 
-    WITH_CURRENT_RESLIST(rl->parent);
     struct childcom* ntc = xcalloc(sizeof (*ntc));
     ntc->from_child = fdh_dup(scon);
     ntc->to_child = fdh_dup(scon);


### PR DESCRIPTION
At the moment when an adb shell command is run the cleanup for setting up a device socket is done as soon as `connect_to_device_socket` exits, meaning that theres a race between the shell command using the socket and it being torn down.

Changing `connect_to_device_socket` so it uses its parents reslist, effectively postponing the teardown till the command has run